### PR TITLE
Pre-release v0.2.0-B2002005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0-B2002005 (pre-release)
+
 - Added new rules for API deprecation removals:
   - Planned Kubernetes v1.17.0 deprecation removals. [#38](https://github.com/Microsoft/PSRule.Rules.Kubernetes/issues/38)
   - Planned Kubernetes v1.20.0 deprecation removals. [#39](https://github.com/Microsoft/PSRule.Rules.Kubernetes/issues/39)


### PR DESCRIPTION
## PR Summary

- Added new rules for API deprecation removals:
  - Planned Kubernetes v1.17.0 deprecation removals. #38
  - Planned Kubernetes v1.20.0 deprecation removals. #39
- **Breaking change**: Use qualified target names. #36
  - If using suppression, update suppressed target name with qualified name.
- **Breaking change**: Renamed `Kubernetes.API.Removal` to handle future API deprecations. #40
  - The rule `Kubernetes.API.Removal` is now `Kubernetes.API.v1.16`.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
